### PR TITLE
Fix Sacred compatibility issues

### DIFF
--- a/docker/Dockerfile.cuda.template
+++ b/docker/Dockerfile.cuda.template
@@ -38,12 +38,14 @@ RUN pip install gym==0.9.2
 RUN pip install gym[atari]
 
 # Sacred and other required packages
-RUN pip install sacred GitPython
+RUN pip install git+https://github.com/IDSIA/Sacred.git@d10a03b4a0087ad06e0f0874a147631e16d1864e
+RUN pip install GitPython
+# RUN pip install sacred GitPython
 
 # Section to get permissions right, and avoid running inside as root {{
     # Create a user matching the UID, and create/chmod home dir (== project directory)
     # (uid corresponds to breord in CS network)
-    RUN useradd -d /project -u <<UID>> --create-home user
+    RUN useradd -d /project -u 1001 --create-home user
     USER user
     WORKDIR /project/
     ADD . /project/


### PR DESCRIPTION
Few issues emerged with the `Sacred` package when reproducing results.
1. The PyPI version had python2/3 compatibility issues, that were addressed
1. The recent versions of Sacred had different interface to use, where `parse_args` was completely removed from the API, so tried to find an old enough version that has a matching interface with this repository. Version used: [0.7b2](https://github.com/IDSIA/sacred/tree/d10a03b4a0087ad06e0f0874a147631e16d1864e)
